### PR TITLE
Add parsing of walksthrough and walksaround

### DIFF
--- a/tibiawikisql/utils/creatures.py
+++ b/tibiawikisql/utils/creatures.py
@@ -5,9 +5,7 @@ from . import deprecated, fetch_category_list, fetch_article_images, fetch_artic
     parse_timestamp
 from .database import get_row_count
 from .parsers import parse_attributes, parse_maximum_integer, parse_integer, parse_boolean, \
-    clean_links, \
-    parse_loot, \
-    parse_min_max, parse_loot_statistics
+    clean_links, parse_loot, parse_min_max, parse_loot_statistics, parse_monster_walks
 
 creatures = []
 
@@ -60,8 +58,8 @@ def fetch_creature(con):
         "drownDmgMod": ("drown", lambda x: parse_integer(x)),
         "hpDrainDmgMod": ("hpdrain", lambda x: parse_integer(x)),
         "abilities": ("abilities", lambda x: clean_links(x)),
-        "walksthrough": ("walksthrough", lambda x: x),
-        "walksaround": ("walksaround", lambda x: x),
+        "walksthrough": ("walksthrough", lambda x: parse_monster_walks(x)),
+        "walksaround": ("walksaround", lambda x: parse_monster_walks(x)),
         "implemented": ("version", lambda x: x)
     }  # type: Dict[str, Tuple[str, Callable]]
     c = con.cursor()

--- a/tibiawikisql/utils/parsers.py
+++ b/tibiawikisql/utils/parsers.py
@@ -249,3 +249,23 @@ def parse_astral_sources(content: str) -> Dict[str, int]:
     materials = astral_pattern.findall(content)
     if materials:
         return {item: int(amount) for (item, amount) in materials}
+
+
+def parse_monster_walks(value: str):
+    """Matches the values against a regex to filter typos or bad data on the wiki. Element names followed by any
+    character that is not a comma will be considered unknown and will not be returned.
+
+    Examples\:
+        - "Poison?, fire" will return fire.
+        - "Poison?, fire." will return neither.
+        - "Poison, earth, fire?, [[ice]]" will return poison and earth.
+        - "No", "--", ">", or "None" will return None.
+    """
+    regex = re.compile(r"(physical)(,|$)|(holy)(,|$)|(death)(,|$)|(fire)(,|$)|(ice)(,|$)|(energy)(,|$)|(earth)(,|$)|"
+                       r"(poison)(,|$)")
+    content = ""
+    for match in re.finditer(regex, value.lower().strip()):
+        content += match.group()
+    if not content:
+        return None
+    return content


### PR DESCRIPTION
Add parsing of walksthrough and walksaround.

Using regex to filter out anything to be considered "unknown element": any element name that contains any special character other than comma will be ignored.

Current element names include: `physical, holy, death, fire, ice, energy, earth and poison`.