### PR TITLE
Add charm information to the database

### DIFF
--- a/tibiawikisql/__main__.py
+++ b/tibiawikisql/__main__.py
@@ -2,12 +2,12 @@ import sys
 import time
 
 from tibiawikisql.utils import database, fetch_deprecated_list, spells, items, npcs, achievements, houses, quests, \
-    creatures, map, imbuements
+    creatures, map, imbuements, charms
 
 DATABASE_FILE = "tibia_database.db"
 SKIP_IMAGES = "skipimages" in sys.argv
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 def main():
@@ -48,6 +48,8 @@ def main():
 
     npcs.save_rashid_locations(con)
 
+    charms.save_charm_list(con)
+
     if not SKIP_IMAGES:
         creatures.fetch_creature_images(con)
         items.fetch_item_images(con)
@@ -55,6 +57,7 @@ def main():
         spells.fetch_spell_images(con)
         imbuements.fetch_imbuements_images(con)
         map.save_maps(con)
+        charms.fetch_charm_images(con)
 
     database.set_database_info(con, __version__)
 

--- a/tibiawikisql/__main__.py
+++ b/tibiawikisql/__main__.py
@@ -7,7 +7,7 @@ from tibiawikisql.utils import database, fetch_deprecated_list, spells, items, n
 DATABASE_FILE = "tibia_database.db"
 SKIP_IMAGES = "skipimages" in sys.argv
 
-__version__ = "1.1.2"
+__version__ = "1.1.1"
 
 
 def main():

--- a/tibiawikisql/utils/charms.json
+++ b/tibiawikisql/utils/charms.json
@@ -3,96 +3,96 @@
     "name": "Wound",
     "type": "Offensive",
     "description": "Wounds the creature and deals 5% of its initial hit points as Physical Damage.",
-    "points": "600"
+    "points": 600
   },
   {
     "name": "Enflame",
     "type": "Offensive",
     "description": "Burns the creature and deals 5% of its initial hit points as Fire Damage.",
-    "points": "1000"
+    "points": 1000
   },
   {
     "name": "Poison",
     "type": "Offensive",
     "description": "Poisons the creature and deals 5% of its initial hit points as Earth Damage.",
-    "points": "600"
+    "points": 600
   },
   {
     "name": "Freeze",
     "type": "Offensive",
     "description": "Freezes the creature and deals 5% of its initial hit points as Ice Damage.",
-    "points": "800"
+    "points": 800
   },
   {
     "name": "Zap",
     "type": "Offensive",
     "description": "Electrifies the creature and deals 5% of its initial hit points as Energy Damage.",
-    "points": "800"
+    "points": 800
   },
   {
     "name": "Curse",
     "type": "Offensive",
     "description": "Curses the creature and deals 5% of its initial hit points as Death Damage.",
-    "points": "900"
+    "points": 900
   },
   {
     "name": "Cripple",
     "type": "Offensive",
     "description": "Cripples the creature and paralyses it for 10 seconds, even if it's immune to the Paralyse Rune.",
-    "points": "500"
+    "points": 500
   },
   {
     "name": "Parry",
     "type": "Defensive",
     "description": "Any damage taken is reflected to the aggressor with a certain chance.",
-    "points": "1000"
+    "points": 1000
   },
   {
     "name": "Dodge",
     "type": "Defensive",
     "description": "Dodges an attack without taking any damage at all.",
-    "points": "600"
+    "points": 600
   },
   {
     "name": "Adrenaline Burst",
     "type": "Defensive",
     "description": "Bursts of adrenaline enhance your reflexes after you get hit and let you move more than twice as faster for 10 seconds.",
-    "points": "500"
+    "points": 500
   },
   {
     "name": "Numb",
     "type": "Defensive",
     "description": "Numbs the creature after its attack and paralyses the creature for 10 seconds, even if it's immune to the Paralyse Rune.",
-    "points": "500"
+    "points": 500
   },
   {
     "name": "Cleanse",
     "type": "Defensive",
     "description": "Cleanses you from within after you get hit and removes one random active negative Status Condition and temporarily makes you immune against it.",
-    "points": "700"
+    "points": 700
   },
   {
     "name": "Bless",
     "type": "Passive",
     "description": "Blesses you and reduces skill and xp loss by 3% when killed by the chosen creature.",
-    "points": "2000"
+    "points": 2000
   },
   {
     "name": "Scavenge",
     "type": "Passive",
     "description": "Enhances your chances to successfully skin a skinnable creature. Applies to Skinning and Dusting.",
-    "points": "1500"
+    "points": 1500
   },
   {
     "name": "Gut",
     "type": "Passive",
     "description": "Gutting the creature yields 10% more Creature Products.",
-    "points": "2000"
+    "points": 2000
   },
   {
     "name": "Low Blow",
     "type": "Passive",
     "description": "Adds 3% critical hit chance to attacks with Critical Hit weapons.",
-    "points": "2000"
+    "points": 2000
   }
 ]

--- a/tibiawikisql/utils/charms.json
+++ b/tibiawikisql/utils/charms.json
@@ -1,0 +1,98 @@
+[
+  {
+    "name": "Wound",
+    "type": "Offensive",
+    "description": "Wounds the creature and deals 5% of its initial hit points as Physical Damage.",
+    "points": "600 points"
+  },
+  {
+    "name": "Enflame",
+    "type": "Offensive",
+    "description": "Burns the creature and deals 5% of its initial hit points as Fire Damage.",
+    "points": "1000 points"
+  },
+  {
+    "name": "Poison",
+    "type": "Offensive",
+    "description": "Poisons the creature and deals 5% of its initial hit points as Earth Damage.",
+    "points": "600 points"
+  },
+  {
+    "name": "Freeze",
+    "type": "Offensive",
+    "description": "Freezes the creature and deals 5% of its initial hit points as Ice Damage.",
+    "points": "800 points"
+  },
+  {
+    "name": "Zap",
+    "type": "Offensive",
+    "description": "Electrifies the creature and deals 5% of its initial hit points as Energy Damage.",
+    "points": "800 points"
+  },
+  {
+    "name": "Curse",
+    "type": "Offensive",
+    "description": "Curses the creature and deals 5% of its initial hit points as Death Damage.",
+    "points": "900 points"
+  },
+  {
+    "name": "Cripple",
+    "type": "Offensive",
+    "description": "Cripples the creature and paralyses it for 10 seconds, even if it's immune to the Paralyse Rune.",
+    "points": "500 points"
+  },
+  {
+    "name": "Parry",
+    "type": "Defensive",
+    "description": "Any damage taken is reflected to the aggressor with a certain chance.",
+    "points": "1000 points"
+  },
+  {
+    "name": "Dodge",
+    "type": "Defensive",
+    "description": "Dodges an attack without taking any damage at all.",
+    "points": "600 points"
+  },
+  {
+    "name": "Adrenaline Burst",
+    "type": "Defensive",
+    "description": "Bursts of adrenaline enhance your reflexes after you get hit and let you move more than twice as faster for 10 seconds.",
+    "points": "500 points"
+  },
+  {
+    "name": "Numb",
+    "type": "Defensive",
+    "description": "Numbs the creature after its attack and paralyses the creature for 10 seconds, even if it's immune to the Paralyse Rune.",
+    "points": "500 points"
+  },
+  {
+    "name": "Cleanse",
+    "type": "Defensive",
+    "description": "Cleanses you from within after you get hit and removes one random active negative Status Condition and temporarily makes you immune against it.",
+    "points": "700 points"
+  },
+  {
+    "name": "Bless",
+    "type": "Passive",
+    "description": "Blesses you and reduces skill and xp loss by 3% when killed by the chosen creature.",
+    "points": "2000 points"
+  },
+  {
+    "name": "Scavenge",
+    "type": "Passive",
+    "description": "Enhances your chances to successfully skin a skinnable creature. Applies to Skinning and Dusting.",
+    "points": "1500 points"
+  },
+  {
+    "name": "Gut",
+    "type": "Passive",
+    "description": "Gutting the creature yields 10% more Creature Products.",
+    "points": "2000 points"
+  },
+  {
+    "name": "Low Blow",
+    "type": "Passive",
+    "description": "Adds 3% critical hit chance to attacks with Critical Hit weapons.",
+    "points": "2000 points"
+  }
+]

--- a/tibiawikisql/utils/charms.json
+++ b/tibiawikisql/utils/charms.json
@@ -3,96 +3,96 @@
     "name": "Wound",
     "type": "Offensive",
     "description": "Wounds the creature and deals 5% of its initial hit points as Physical Damage.",
-    "points": "600 points"
+    "points": "600"
   },
   {
     "name": "Enflame",
     "type": "Offensive",
     "description": "Burns the creature and deals 5% of its initial hit points as Fire Damage.",
-    "points": "1000 points"
+    "points": "1000"
   },
   {
     "name": "Poison",
     "type": "Offensive",
     "description": "Poisons the creature and deals 5% of its initial hit points as Earth Damage.",
-    "points": "600 points"
+    "points": "600"
   },
   {
     "name": "Freeze",
     "type": "Offensive",
     "description": "Freezes the creature and deals 5% of its initial hit points as Ice Damage.",
-    "points": "800 points"
+    "points": "800"
   },
   {
     "name": "Zap",
     "type": "Offensive",
     "description": "Electrifies the creature and deals 5% of its initial hit points as Energy Damage.",
-    "points": "800 points"
+    "points": "800"
   },
   {
     "name": "Curse",
     "type": "Offensive",
     "description": "Curses the creature and deals 5% of its initial hit points as Death Damage.",
-    "points": "900 points"
+    "points": "900"
   },
   {
     "name": "Cripple",
     "type": "Offensive",
     "description": "Cripples the creature and paralyses it for 10 seconds, even if it's immune to the Paralyse Rune.",
-    "points": "500 points"
+    "points": "500"
   },
   {
     "name": "Parry",
     "type": "Defensive",
     "description": "Any damage taken is reflected to the aggressor with a certain chance.",
-    "points": "1000 points"
+    "points": "1000"
   },
   {
     "name": "Dodge",
     "type": "Defensive",
     "description": "Dodges an attack without taking any damage at all.",
-    "points": "600 points"
+    "points": "600"
   },
   {
     "name": "Adrenaline Burst",
     "type": "Defensive",
     "description": "Bursts of adrenaline enhance your reflexes after you get hit and let you move more than twice as faster for 10 seconds.",
-    "points": "500 points"
+    "points": "500"
   },
   {
     "name": "Numb",
     "type": "Defensive",
     "description": "Numbs the creature after its attack and paralyses the creature for 10 seconds, even if it's immune to the Paralyse Rune.",
-    "points": "500 points"
+    "points": "500"
   },
   {
     "name": "Cleanse",
     "type": "Defensive",
     "description": "Cleanses you from within after you get hit and removes one random active negative Status Condition and temporarily makes you immune against it.",
-    "points": "700 points"
+    "points": "700"
   },
   {
     "name": "Bless",
     "type": "Passive",
     "description": "Blesses you and reduces skill and xp loss by 3% when killed by the chosen creature.",
-    "points": "2000 points"
+    "points": "2000"
   },
   {
     "name": "Scavenge",
     "type": "Passive",
     "description": "Enhances your chances to successfully skin a skinnable creature. Applies to Skinning and Dusting.",
-    "points": "1500 points"
+    "points": "1500"
   },
   {
     "name": "Gut",
     "type": "Passive",
     "description": "Gutting the creature yields 10% more Creature Products.",
-    "points": "2000 points"
+    "points": "2000"
   },
   {
     "name": "Low Blow",
     "type": "Passive",
     "description": "Adds 3% critical hit chance to attacks with Critical Hit weapons.",
-    "points": "2000 points"
+    "points": "2000"
   }
 ]

--- a/tibiawikisql/utils/charms.py
+++ b/tibiawikisql/utils/charms.py
@@ -11,6 +11,8 @@ from tibiawikisql.utils import ENDPOINT, headers
 
 
 def save_charm_list(con):
+    print("Parsing charm information from json...")
+    start_time = time.time()
     with open(pkg_resources.resource_filename(__name__, "charms.json")) as file:
         charms = json.load(file)
     c = con.cursor()
@@ -19,6 +21,7 @@ def save_charm_list(con):
                   (charm["name"], charm["type"], charm["description"], charm["points"]))
     con.commit()
     c.close()
+    print(f"Parsing done in {time.time()-start_time:.3f} seconds.")
 
 
 def fetch_charm_images(con):

--- a/tibiawikisql/utils/charms.py
+++ b/tibiawikisql/utils/charms.py
@@ -1,0 +1,99 @@
+import json
+import os
+from contextlib import closing
+
+import pkg_resources
+import time
+
+import requests
+
+from tibiawikisql.utils import ENDPOINT, headers
+
+
+def save_charm_list(con):
+    with open(pkg_resources.resource_filename(__name__, "charms.json")) as file:
+        charms = json.load(file)
+    c = con.cursor()
+    for charm in charms:
+        c.execute("INSERT INTO charm(name, type, description, points) VALUES(?,?,?,?)",
+                  (charm["name"], charm["type"], charm["description"], charm["points"]))
+    con.commit()
+    c.close()
+
+
+def fetch_charm_images(con):
+    print("Fetching charm images...")
+    start_time = time.time()
+    fetch_images_from_name(con)
+    print(f"\tFetched charm images in {time.time()-start_time:.3f} seconds.")
+
+
+def fetch_images_from_name(con):
+    """Generic function to fetch images directly from their names.
+    It goes through a list of image names, checks for it in the images folder and downloads the ones that don't exist.
+
+    The purpose is to be used on images that don't have a specific article.
+    """
+    with closing(con.cursor()) as c:
+        charms = _get_charms_from_db(c)
+        os.makedirs(f"images/charm", exist_ok=True)
+        extension = ".png"
+        data = _request_data_from_wiki(charms, extension)
+        try:
+            image_pages = data["query"]["pages"]
+        except TypeError:
+            print("Charms Error: fetching images failed.")
+            return
+        for article_id, article in image_pages.items():
+            charm_name = article["title"].replace("File:", "").replace(extension, "")
+            img_url = article["imageinfo"][0]["url"]
+            try:
+                if os.path.exists(f"images/charm/{charm_name}{extension}"):
+                    image = _get_image_from_dir(charm_name, extension)
+                else:
+                    image = _write_response_image_to_dir(img_url, charm_name, extension)
+                _insert_image_in_db(c, con, charms[charm_name], image)
+            except requests.HTTPError:
+                print(f"HTTP Error fetching image for {charm_name}")
+                continue
+
+
+def _insert_image_in_db(c, con, charm_id, image):
+    c.execute(f"UPDATE charm SET image = ? WHERE id = ?", (image, charm_id))
+    con.commit()
+
+
+def _write_response_image_to_dir(img_url, charm_name, extension):
+    r = requests.get(img_url)
+    r.raise_for_status()
+    image = r.content
+    with open(f"images/charm/{charm_name}{extension}", "wb") as f:
+        f.write(image)
+    return image
+
+
+def _get_image_from_dir(charm_name, extension):
+    with open(f"images/charm/{charm_name}{extension}", "rb") as f:
+        image = f.read()
+    return image
+
+
+def _request_data_from_wiki(charms, extension):
+    params = {
+        "action": "query",
+        "prop": "imageinfo",
+        "iiprop": "url",
+        "format": "json",
+        "titles": "|".join([f"File:{charm_name}{extension}" for charm_name in charms.keys()])
+    }
+    r = requests.get(ENDPOINT, headers=headers, params=params)
+    data = json.loads(r.text)
+    return data
+
+
+def _get_charms_from_db(c):
+    c.execute("SELECT id, name FROM charm")
+    charms = {}
+    for row in c.fetchall():
+        charms[row[1]] = row[0]
+    return charms

--- a/tibiawikisql/utils/charms.py
+++ b/tibiawikisql/utils/charms.py
@@ -47,7 +47,7 @@ def fetch_images_from_name(con):
         except TypeError:
             print("Charms Error: fetching images failed.")
             return
-        for article_id, article in image_pages.items():
+        for article in image_pages.values():
             charm_name = article["title"].replace("File:", "").replace(extension, "")
             img_url = article["imageinfo"][0]["url"]
             try:

--- a/tibiawikisql/utils/database.py
+++ b/tibiawikisql/utils/database.py
@@ -318,6 +318,18 @@ def init_database(name):
             FOREIGN KEY(`item_id`) REFERENCES `items`(`id`)
          );
          """)
+
+        con.execute("DROP TABLE IF EXISTS charm")
+        con.execute("""
+                    CREATE TABLE `charm` (
+                        `id` INTEGER PRIMARY KEY,
+                        `name` TEXT,
+                        `type` TEXT,
+                        `description` TEXT,
+                        `points` INTEGER,
+                        `image` BLOB
+                     );
+                     """)
     return con
 
 


### PR DESCRIPTION
Add charm information to the database.

This closes #18.

- JSON file added with information for all charms
  - Done this way because charms don't have their own articles
- `charm` table created and populated from JSON
  - Images are requested from wiki if not existing locally