### PR TITLE
Add spell base power to parser, schema and models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add spell base power (`base_power`) to parser, schema and models.
+
 ## 8.0.1 (2026-06-16)
 
 - Add support for new NPC transport template.

--- a/tests/resources/content_spell.txt
+++ b/tests/resources/content_spell.txt
@@ -5,6 +5,7 @@
 | type          = Instant
 | subclass      = Attack
 | damagetype    = Fire
+| basepower     = 45
 | words         = exori flam
 | premium       = yes
 | mana          = 20

--- a/tests/tests_models.py
+++ b/tests/tests_models.py
@@ -241,12 +241,14 @@ class TestModels(unittest.TestCase):
                           content=load_resource("content_spell.txt"))
         spell = models.Spell.from_article(article)
         self.assertIsInstance(spell, models.Spell)
+        self.assertEqual(spell.base_power, 45)
 
         spell.insert(self.conn)
         db_spell = models.Spell.get_one_by_field(self.conn, "article_id", 1)
 
         self.assertIsInstance(db_spell, models.Spell)
         self.assertEqual(db_spell.name, spell.name)
+        self.assertEqual(db_spell.base_power, spell.base_power)
 
     def test_world(self):
         article = Article(1, "Mortera", timestamp="2018-08-20T04:33:15Z",

--- a/tests/tests_parsers.py
+++ b/tests/tests_parsers.py
@@ -3,8 +3,8 @@ import unittest
 
 from tests import load_resource
 from tibiawikisql.api import Article
-from tibiawikisql.models import Achievement
-from tibiawikisql.parsers import AchievementParser
+from tibiawikisql.models import Achievement, Spell
+from tibiawikisql.parsers import AchievementParser, SpellParser
 
 
 class TestParsers(unittest.TestCase):
@@ -19,5 +19,18 @@ class TestParsers(unittest.TestCase):
         achievement = AchievementParser.from_article(article)
 
         self.assertIsInstance(achievement, Achievement)
+
+    def test_spell_parser_success(self):
+        article = Article(
+            article_id=1,
+            title="Flame Strike",
+            timestamp=datetime.datetime.fromisoformat("2018-08-20T04:33:15+00:00"),
+            content=load_resource("content_spell.txt"),
+        )
+
+        spell = SpellParser.from_article(article)
+
+        self.assertIsInstance(spell, Spell)
+        self.assertEqual(spell.base_power, 45)
 
 

--- a/tibiawikisql/models/spell.py
+++ b/tibiawikisql/models/spell.py
@@ -24,6 +24,8 @@ class Spell(WikiEntry, WithVersion, WithStatus, WithImage, RowModel, table=Spell
     """The group of the rune created by this spell."""
     element: str | None = Field(None)
     """The element of the damage made by the spell."""
+    base_power: int | None = Field(None)
+    """The spell's base power, used to determine its damage or healing."""
     mana: int
     """The mana cost of the spell."""
     soul: int

--- a/tibiawikisql/parsers/spell.py
+++ b/tibiawikisql/parsers/spell.py
@@ -23,6 +23,7 @@ class SpellParser(BaseParser):
         "group_secondary": AttributeParser.optional("secondarygroup"),
         "group_rune": AttributeParser.optional("runegroup"),
         "element": AttributeParser.optional("damagetype"),
+        "base_power": AttributeParser.optional("basepower", parse_integer),
         "mana": AttributeParser.optional("mana", parse_integer),
         "soul": AttributeParser.optional("soul", parse_integer, 0),
         "cooldown": AttributeParser.required("cooldown"),

--- a/tibiawikisql/schema.py
+++ b/tibiawikisql/schema.py
@@ -340,6 +340,7 @@ class SpellTable(Table):
     group_secondary = Column(Text, index=True)
     group_rune = Column(Text, index=True)
     element = Column(Text, index=True)
+    base_power = Column(Integer, nullable=True)
     level = Column(Integer)
     mana = Column(Integer)
     soul = Column(Integer, default=0)


### PR DESCRIPTION
TibiaWiki's Infobox Spell template now includes a `basepower` parameter (e.g. Flame Strike has `basepower = 45`), but it wasn't being parsed.

This adds it end to end:

- `SpellTable` gets a `base_power` integer column.
- `Spell` model gets an optional `base_power` field.
- `SpellParser` maps `basepower` through `parse_integer`.
- Updated the Flame Strike test fixture to match the current live article and added a spell parser test asserting the value round-trips.
- Added a changelog entry under Unreleased.

Full test suite passes (`python -m unittest discover`), ruff reports nothing new on the touched files.